### PR TITLE
fix: avoid nil pointer dereference when comparing unparseable versions

### DIFF
--- a/pkg/controller/update.go
+++ b/pkg/controller/update.go
@@ -286,6 +286,15 @@ func compareVersion(currentVersion, newVersion string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("parse the new version: %w", err)
 	}
+	// GetVersionAndPrefix returns a nil version without an error when the tag
+	// isn't a valid version (e.g. a commit hash). Comparing such versions would
+	// cause a nil pointer dereference, so bail out instead.
+	if cv == nil {
+		return false, fmt.Errorf("the current version isn't a valid version: %s", currentVersion)
+	}
+	if nv == nil {
+		return false, fmt.Errorf("the new version isn't a valid version: %s", newVersion)
+	}
 	if cvPrefix != nvPrefix {
 		return false, nil
 	}

--- a/pkg/controller/update_internal_test.go
+++ b/pkg/controller/update_internal_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func Test_compareVersion(t *testing.T) {
+func Test_compareVersion(t *testing.T) { //nolint:funlen
 	t.Parallel()
 	data := []struct {
 		name           string

--- a/pkg/controller/update_internal_test.go
+++ b/pkg/controller/update_internal_test.go
@@ -41,6 +41,18 @@ func Test_compareVersion(t *testing.T) {
 			newVersion:     "cli-v2.0.0",
 			f:              false,
 		},
+		{
+			name:           "current version is a commit hash",
+			currentVersion: "cd684900348e6c23335064bf74c8368e3abcec5e",
+			newVersion:     "v0.1.3",
+			isErr:          true,
+		},
+		{
+			name:           "new version is a commit hash",
+			currentVersion: "v0.1.3",
+			newVersion:     "cd684900348e6c23335064bf74c8368e3abcec5e",
+			isErr:          true,
+		},
 	}
 	for _, d := range data {
 		t.Run(d.name, func(t *testing.T) {


### PR DESCRIPTION
## Overview

Fixes a `nil pointer dereference` panic in `aqua-registry-updater` reported in [aquaproj/aqua-registry#54870](https://github.com/aquaproj/aqua-registry/issues/54870).

## Background

The updater crashed with a SIGSEGV while handling the `Azure/mapotf` package:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x9569de]

github.com/hashicorp/go-version.(*Version).String(0x0)
github.com/hashicorp/go-version.(*Version).Compare(0xc0000fc190, 0x0)
github.com/hashicorp/go-version.(*Version).GreaterThan(...)
github.com/aquaproj/aqua-registry-updater/pkg/controller.compareVersion(...)
    pkg/controller/update.go:292
```

## Root cause

`Azure/mapotf`'s `pkg.yaml` pins a **commit hash** (`cd684900348e6c23335064bf74c8368e3abcec5e`) instead of a version tag.

`versiongetter.GetVersionAndPrefix` (in `aqua/v2`) returns a **nil `*version.Version` without an error** when the input isn't a valid version (such as a commit hash):

```go
a := versionPattern.FindStringSubmatch(tag)
if a == nil {
    return nil, "", nil // nil version, nil error
}
```

`compareVersion` did not check for this nil version, so `nv.GreaterThan(cv)` was called with `cv == nil`, dereferencing a nil pointer inside go-version and crashing the whole process.

## Changes

- `pkg/controller/update.go`: In `compareVersion`, return an error if either the current or new parsed version is `nil` instead of proceeding to the comparison. The caller already handles a `compareVersion` error by logging a warning and continuing (creating a PR without enabling auto-merge), so this turns a hard crash into graceful degradation.
- `pkg/controller/update_internal_test.go`: Add two test cases covering a commit hash as the current version and as the new version, asserting an error is returned.

## Testing

- `go test ./pkg/controller/ -run Test_compareVersion -v` — all cases pass.
- `go build ./...` — succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)