### PR TITLE
feat: close superseded update pull requests

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -15,8 +15,7 @@ type ParamNew struct {
 }
 
 type Controller struct {
-	fs afero.Fs
-	// repo   RepositoriesService
+	fs     afero.Fs
 	pull   PullRequestsService
 	stdout io.Writer
 	stderr io.Writer
@@ -25,6 +24,9 @@ type Controller struct {
 
 type PullRequestsService interface {
 	Create(ctx context.Context, owner, repo string, pull *github.NewPullRequest) (*github.PullRequest, *github.Response, error)
+	Edit(ctx context.Context, owner, repo string, number int, pull *github.PullRequest) (*github.PullRequest, *github.Response, error)
+	List(ctx context.Context, owner, repo string, opts *github.PullRequestListOptions) ([]*github.PullRequest, *github.Response, error)
+	ListFiles(ctx context.Context, owner, repo string, number int, opts *github.ListOptions) ([]*github.CommitFile, *github.Response, error)
 }
 
 func New(fs afero.Fs, param *ParamNew, pull PullRequestsService) *Controller {

--- a/pkg/controller/github.go
+++ b/pkg/controller/github.go
@@ -29,7 +29,7 @@ type ParamCreatePR struct {
 func (c *Controller) createPR(ctx context.Context, param *ParamCreatePR) (int, error) {
 	pr, _, err := c.pull.Create(ctx, c.param.RepoOwner, c.param.RepoName, &github.NewPullRequest{
 		Head:  new(param.Branch),
-		Base:  new("main"),
+		Base:  new(defaultBranchName),
 		Title: new(param.Title),
 		Body:  new(param.Body),
 	})

--- a/pkg/controller/pull_request.go
+++ b/pkg/controller/pull_request.go
@@ -1,0 +1,170 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/aquaproj/aqua/v2/pkg/versiongetter"
+	"github.com/google/go-github/v89/github"
+	"github.com/spf13/afero"
+	"github.com/suzuki-shunsuke/slog-error/slogerr"
+)
+
+const (
+	defaultBranchName  = "main"
+	updateBranchPrefix = "aqua-registry-updater-"
+	updatePRAuthor     = "aquaproj-aqua-registry[bot]"
+)
+
+func (c *Controller) listOpenUpdatePRs(ctx context.Context) ([]*github.PullRequest, error) {
+	opts := &github.PullRequestListOptions{
+		State:       "open",
+		Base:        defaultBranchName,
+		ListOptions: github.ListOptions{PerPage: 100},
+	}
+	prs := []*github.PullRequest{}
+	for {
+		page, resp, err := c.pull.List(ctx, c.param.RepoOwner, c.param.RepoName, opts)
+		if err != nil {
+			return nil, fmt.Errorf("list pull requests: %w", err)
+		}
+		prs = append(prs, page...)
+		if resp.NextPage == 0 {
+			return prs, nil
+		}
+		opts.Page = resp.NextPage
+	}
+}
+
+func (c *Controller) closeSupersededUpdatePRs(ctx context.Context, logger *slog.Logger, paths, packages []string) error {
+	prs, err := c.listOpenUpdatePRs(ctx)
+	if err != nil {
+		return err
+	}
+	pkgPaths := make(map[string]string, len(paths))
+	for _, path := range paths {
+		pkgPaths[packageNameFromPath(path)] = path
+	}
+	selected := make(map[string]struct{}, len(packages))
+	for _, pkgName := range packages {
+		selected[pkgName] = struct{}{}
+	}
+	repo := c.param.RepoOwner + "/" + c.param.RepoName
+	for _, pr := range prs {
+		if err := c.closeSupersededUpdatePR(ctx, logger, pr, repo, pkgPaths, selected); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Controller) closeSupersededUpdatePR(ctx context.Context, logger *slog.Logger, pr *github.PullRequest, repo string, pkgPaths map[string]string, selected map[string]struct{}) error {
+	if pr.GetUser().GetLogin() != updatePRAuthor || pr.GetHead().GetRepo().GetFullName() != repo {
+		return nil
+	}
+	superseded, err := c.supersededUpdates(logger, pr, pkgPaths, selected)
+	if err != nil {
+		return err
+	}
+	if len(superseded) == 0 {
+		return nil
+	}
+	pkgName, ok, err := c.changedPackage(ctx, pr, pkgPaths, superseded)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	logger.Info("closing a superseded update pull request",
+		"pull_request_number", pr.GetNumber(), "pkg_name", pkgName)
+	if _, _, err := c.pull.Edit(ctx, c.param.RepoOwner, c.param.RepoName, pr.GetNumber(), &github.PullRequest{
+		State: new("closed"),
+	}); err != nil {
+		return fmt.Errorf("close pull request #%d: %w", pr.GetNumber(), err)
+	}
+	return nil
+}
+
+func (c *Controller) supersededUpdates(logger *slog.Logger, pr *github.PullRequest, pkgPaths map[string]string, selected map[string]struct{}) (map[string]string, error) {
+	superseded := make(map[string]string)
+	for pkgName, proposedVersion := range proposedUpdates(pr.GetHead().GetRef(), pkgPaths) {
+		if len(selected) != 0 {
+			if _, ok := selected[pkgName]; !ok {
+				continue
+			}
+		}
+		body, err := afero.ReadFile(c.fs, pkgPaths[pkgName])
+		if err != nil {
+			return nil, fmt.Errorf("read pkg.yaml: %w", err)
+		}
+		currentVersion, err := c.getCurrentVersion(pkgName, string(body))
+		if err != nil {
+			return nil, fmt.Errorf("get the current version: %w", err)
+		}
+		closePR, err := isCurrentVersionSameOrNewer(currentVersion, proposedVersion)
+		if err != nil {
+			slogerr.WithError(logger, err).Warn("skip an incomparable update pull request",
+				"pull_request_number", pr.GetNumber())
+			continue
+		}
+		if closePR {
+			superseded[pkgName] = proposedVersion
+		}
+	}
+	return superseded, nil
+}
+
+func proposedUpdates(branch string, pkgPaths map[string]string) map[string]string {
+	candidates := make(map[string]string)
+	for pkgName := range pkgPaths {
+		version, ok := strings.CutPrefix(branch, updateBranchPrefix+pkgName+"-")
+		if ok {
+			candidates[pkgName] = version
+		}
+	}
+	return candidates
+}
+
+func (c *Controller) changedPackage(ctx context.Context, pr *github.PullRequest, pkgPaths, candidates map[string]string) (string, bool, error) {
+	files, _, err := c.pull.ListFiles(ctx, c.param.RepoOwner, c.param.RepoName, pr.GetNumber(), nil)
+	if err != nil {
+		return "", false, fmt.Errorf("list files of pull request #%d: %w", pr.GetNumber(), err)
+	}
+	if len(files) != 1 {
+		return "", false, nil
+	}
+	for pkgName := range candidates {
+		if files[0].GetFilename() == pkgPaths[pkgName] {
+			return pkgName, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+func isCurrentVersionSameOrNewer(currentVersion, proposedVersion string) (bool, error) {
+	current, currentPrefix, err := versiongetter.GetVersionAndPrefix(currentVersion)
+	if err != nil {
+		return false, fmt.Errorf("parse the current version %s: %w", currentVersion, err)
+	}
+	if current == nil {
+		return false, fmt.Errorf("the current version isn't valid: %s", currentVersion)
+	}
+	proposed, proposedPrefix, err := versiongetter.GetVersionAndPrefix(proposedVersion)
+	if err != nil {
+		return false, fmt.Errorf("parse the proposed version %s: %w", proposedVersion, err)
+	}
+	if proposed == nil {
+		return false, fmt.Errorf("the proposed version isn't valid: %s", proposedVersion)
+	}
+	if currentPrefix != proposedPrefix {
+		return false, nil
+	}
+	return currentVersion == proposedVersion || current.GreaterThan(proposed), nil
+}
+
+func packageNameFromPath(path string) string {
+	return strings.TrimSuffix(strings.TrimPrefix(path, "pkgs/"), "/pkg.yaml")
+}

--- a/pkg/controller/pull_request_internal_test.go
+++ b/pkg/controller/pull_request_internal_test.go
@@ -1,0 +1,167 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/google/go-github/v89/github"
+	"github.com/spf13/afero"
+)
+
+const (
+	testInvalidVersion = "branch"
+	testJena610        = "jena-6.1.0"
+)
+
+func Test_isCurrentVersionSameOrNewer(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		current  string
+		proposed string
+		closePR  bool
+		wantErr  bool
+	}{
+		"same":                    {testJena610, testJena610, true, false},
+		"newer":                   {"jena-6.2.0", testJena610, true, false},
+		"older":                   {"jena-6.0.0", testJena610, false, false},
+		"distinct build metadata": {"v1.36.2+k3s1", "v1.36.2+k3s2", false, false},
+		"distinct normalized tag": {"v1.2", "v1.2.0", false, false},
+		"different prefix":        {"edge-v2.0.0", "stable-v2.0.0", false, false},
+		"same invalid version":    {testInvalidVersion, testInvalidVersion, false, true},
+		"invalid current":         {testInvalidVersion, "v1.0.0", false, true},
+		"invalid proposed":        {"v1.0.0", testInvalidVersion, false, true},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			closePR, err := isCurrentVersionSameOrNewer(test.current, test.proposed)
+			if closePR != test.closePR || (err != nil) != test.wantErr {
+				t.Fatalf("got (%v, %v), want (%v, error=%v)", closePR, err, test.closePR, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestController_closeSupersededUpdatePRs(t *testing.T) {
+	t.Parallel()
+	ctrl, pull, paths := newTestController(t)
+	if err := ctrl.closeSupersededUpdatePRs(
+		context.Background(), slog.New(slog.DiscardHandler), paths, nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if len(pull.editedNumbers) != 3 ||
+		pull.editedNumbers[0] != 53169 ||
+		pull.editedNumbers[1] != 3 ||
+		pull.editedNumbers[2] != 4 {
+		t.Fatalf("wanted pull requests [53169 3 4] to be closed, got %v", pull.editedNumbers)
+	}
+	if len(pull.listFilesNumbers) != 3 ||
+		pull.listFilesNumbers[0] != 53169 ||
+		pull.listFilesNumbers[1] != 3 ||
+		pull.listFilesNumbers[2] != 4 {
+		t.Fatalf("wanted files of pull requests [53169 3 4] to be listed, got %v", pull.listFilesNumbers)
+	}
+}
+
+func TestController_closeSupersededUpdatePRs_targeted(t *testing.T) {
+	t.Parallel()
+	ctrl, pull, paths := newTestController(t)
+	if err := ctrl.closeSupersededUpdatePRs(
+		context.Background(), slog.New(slog.DiscardHandler), paths, []string{"owner/tool"},
+	); err != nil {
+		t.Fatal(err)
+	}
+	if len(pull.editedNumbers) != 1 || pull.editedNumbers[0] != 3 {
+		t.Fatalf("wanted only pull request 3 to be closed, got %v", pull.editedNumbers)
+	}
+}
+
+type fakePullRequestsService struct {
+	editedNumbers    []int
+	listFilesNumbers []int
+}
+
+func (*fakePullRequestsService) Create(context.Context, string, string, *github.NewPullRequest) (*github.PullRequest, *github.Response, error) {
+	return nil, nil, errors.New("not implemented")
+}
+
+func (f *fakePullRequestsService) Edit(_ context.Context, _, _ string, number int, pull *github.PullRequest) (*github.PullRequest, *github.Response, error) {
+	if pull.GetState() != "closed" {
+		return nil, nil, errors.New("pull request state must be closed")
+	}
+	f.editedNumbers = append(f.editedNumbers, number)
+	return pull, &github.Response{}, nil
+}
+
+func (*fakePullRequestsService) List(_ context.Context, _, _ string, opts *github.PullRequestListOptions) ([]*github.PullRequest, *github.Response, error) {
+	if opts.State != "open" || opts.Base != defaultBranchName || opts.PerPage != 100 {
+		return nil, nil, errors.New("unexpected list options")
+	}
+	if opts.Page == 0 {
+		return []*github.PullRequest{
+			newUpdatePullRequest(53169, updatePRAuthor, "apache/jena", testJena610),
+			newUpdatePullRequest(1, "octocat", "apache/jena", testJena610),
+		}, &github.Response{NextPage: 2}, nil
+	}
+	return []*github.PullRequest{
+		newUpdatePullRequest(2, updatePRAuthor, "apache/jena", "jena-6.2.0"),
+		newUpdatePullRequest(3, updatePRAuthor, "owner/tool-extra", "v1.0.0"),
+		newUpdatePullRequest(4, updatePRAuthor, "apache/jena", "jena-6.0.0"),
+	}, &github.Response{}, nil
+}
+
+func (f *fakePullRequestsService) ListFiles(_ context.Context, _, _ string, number int, _ *github.ListOptions) ([]*github.CommitFile, *github.Response, error) {
+	f.listFilesNumbers = append(f.listFilesNumbers, number)
+	filename := "pkgs/apache/jena/pkg.yaml"
+	if number == 3 {
+		filename = "pkgs/owner/tool/pkg.yaml"
+	}
+	return []*github.CommitFile{
+		{Filename: new(filename)},
+	}, &github.Response{}, nil
+}
+
+func newUpdatePullRequest(number int, author, pkg, version string) *github.PullRequest {
+	return &github.PullRequest{
+		Number: new(number),
+		User:   &github.User{Login: new(author)},
+		Head: &github.PullRequestBranch{
+			Ref:  new(updateBranchPrefix + pkg + "-" + version),
+			Repo: &github.Repository{FullName: new("aquaproj/aqua-registry")},
+		},
+	}
+}
+
+func writePkgYAML(t *testing.T, fs afero.Fs, path, pkg, version string) {
+	t.Helper()
+	if err := fs.MkdirAll(strings.TrimSuffix(path, "/pkg.yaml"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "packages:\n  - name: " + pkg + "@" + version + "\n"
+	if err := afero.WriteFile(fs, path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newTestController(t *testing.T) (*Controller, *fakePullRequestsService, []string) {
+	t.Helper()
+	fs := afero.NewMemMapFs()
+	paths := []string{
+		"pkgs/apache/jena/pkg.yaml",
+		"pkgs/owner/tool/pkg.yaml",
+		"pkgs/owner/tool-extra/pkg.yaml",
+	}
+	writePkgYAML(t, fs, paths[0], "apache/jena", testJena610)
+	writePkgYAML(t, fs, paths[1], "owner/tool", "extra-v2.0.0")
+	writePkgYAML(t, fs, paths[2], "owner/tool-extra", "v0.9.0")
+	pull := &fakePullRequestsService{}
+	return &Controller{
+		fs:    fs,
+		pull:  pull,
+		param: &ParamNew{RepoOwner: "aquaproj", RepoName: "aqua-registry"},
+	}, pull, paths
+}

--- a/pkg/controller/update.go
+++ b/pkg/controller/update.go
@@ -57,6 +57,9 @@ func (c *Controller) Update(ctx context.Context, logger *slog.Logger, param *Par
 	if err != nil {
 		return fmt.Errorf("search pkg.yaml: %w", err)
 	}
+	if err := c.closeSupersededUpdatePRs(ctx, logger, pkgPaths, param.Args); err != nil {
+		return fmt.Errorf("close superseded update pull requests: %w", err)
+	}
 
 	ignorePkgsM := make(map[string]struct{}, len(cfg.IgnorePackages))
 	for _, pkg := range cfg.IgnorePackages {


### PR DESCRIPTION
## Summary

Close updater-created pull requests when `pkg.yaml` on `main` already contains the same or a newer version.

## Motivation

An update pull request can remain open when its version lands through another pull request. For example, aquaproj/aqua-registry#53169 remained open after aquaproj/aqua-registry#53903 put `jena-6.1.0` on `main`.

The updater currently sees that no package update is needed and returns without reconciling the existing pull request. The aqua-registry cleanup workflow only closes conflicting pull requests, while this kind of superseded pull request remains mergeable.

## Implementation

- reconcile open update pull requests before ignore, scaffold, and redirect handling
- require the updater bot author and a branch in the target repository
- compare exact tag equality or a strictly newer semantic version with the same prefix
- verify the PR's changed `pkg.yaml` before closing, including ambiguous package-name prefixes
- preserve package scope when the updater is invoked with explicit package arguments
- leave differently prefixed, non-semver, or otherwise ambiguous updates unchanged

`ListFiles` is called only after a candidate already compares equal or newer, avoiding an extra request for every open update pull request.

## Verification

```console
$ go test ./... -race -covermode=atomic
ok  	github.com/aquaproj/aqua-registry-updater/pkg/controller	1.033s	coverage: 16.4% of statements

$ go vet ./...

$ golangci-lint run
0 issues.
```
